### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/pankajkumar2014/a9f64c09-94f4-4ac0-a7d5-07d0eb78ed38/61753397-e76e-40b6-8cfe-d2dc283f43ea/_apis/work/boardbadge/5dd3ba35-f287-4140-92ff-ea87c0c4c6e8)](https://dev.azure.com/pankajkumar2014/a9f64c09-94f4-4ac0-a7d5-07d0eb78ed38/_boards/board/t/61753397-e76e-40b6-8cfe-d2dc283f43ea/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://dev.azure.com/pankajkumar2014/a9f64c09-94f4-4ac0-a7d5-07d0eb78ed38/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.